### PR TITLE
fix: gapsId is also required in /horaires endpoint

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -24,6 +24,7 @@ router.post(
     "/horaires",
     body("username").isLength({ min: 3 }),
     body("password").isLength({ min: 4 }),
+    body("gapsId").isLength({ min: 1 }),
     decrypt,
     getHoraires
 );


### PR DESCRIPTION
I think this required field was missing 🙌